### PR TITLE
New Feature: open glyph list in external text editor (TSV format)

### DIFF
--- a/PersonaEditor/Views/Tools/SetChar.xaml
+++ b/PersonaEditor/Views/Tools/SetChar.xaml
@@ -11,7 +11,7 @@
     <i:Interaction.Behaviors>
         <beh:ClosingWindowBehavior Closing="{Binding Closing}" />
     </i:Interaction.Behaviors>
-    
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -20,6 +20,7 @@
 
         <StatusBar>
             <ComboBox Width="100" ItemsSource="{Binding FontList}" SelectedIndex="{Binding FontSelect}"/>
+            <Button Content="Open in Text Editor" Command="{Binding ExternalEdit}"/>
         </StatusBar>
 
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">


### PR DESCRIPTION
I added a simple feature: opening the loaded glyph list in an external text editor. With the external text editor, users can freely modify the glyph list with automation tools (e.g., OCR text recognition), as well as copy & paste from other glyph lists.

The text file format is TSV, which is a commonly used format in several Persona mod tools.

Inspired by: https://github.com/Meloman19/PersonaEditor/issues/32#issuecomment-1704776905